### PR TITLE
fix: add missing TASK_GENERATOR_ADDRESS to Makefile deploy-policy com…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,6 @@ deploy-policy:
 	@source .env; \
 	DIRECTORY=$$(pwd); \
 	cd newton-contracts; \
-	PRIVATE_KEY=$$PRIVATE_KEY ETHERSCAN_API_KEY=$$ETHERSCAN_API_KEY POLICY_CIDS_PATH="$$DIRECTORY/policy-files/policy_cids.json" EXPIRE_AFTER=$(EXPIRE_AFTER) forge script script/PolicyDeployer.s.sol --rpc-url $$RPC_URL --private-key $$PRIVATE_KEY --broadcast
+	PRIVATE_KEY=$$PRIVATE_KEY ETHERSCAN_API_KEY=$$ETHERSCAN_API_KEY POLICY_CIDS_PATH="$$DIRECTORY/policy-files/policy_cids.json" TASK_GENERATOR_ADDRESS=$$TASK_GENERATOR_ADDRESS EXPIRE_AFTER=$(EXPIRE_AFTER) forge script script/PolicyDeployer.s.sol --rpc-url $$RPC_URL --private-key $$PRIVATE_KEY --broadcast
 
 upload-and-deploy-policy: create-policy-cids-json deploy-policy


### PR DESCRIPTION
Fix: Missing TASK_GENERATOR_ADDRESS environment variable in deployment

# Problem

The `make deploy-policy` command was failing with the error:

```bash
vm.envAddress: environment variable "TASK_GENERATOR_ADDRESS" not found
```

Even though the TASK_GENERATOR_ADDRESS was properly defined in the `.env` file, the Makefile wasn't passing it to the forge script command.

# Solution

Added `TASK_GENERATOR_ADDRESS=$$TASK_GENERATOR_ADDRESS` to the environment variables explicitly passed to the forge script in the `deploy-policy` target.

# Changes

- Updated Makefile `line 183` to include `TASK_GENERATOR_ADDRESS` in the environment variables passed to the forge deployment script

# Testing

- Verified that make `deploy-policy` now successfully reads the `TASK_GENERATOR_ADDRESS` from the `.env` file
- Deployment script no longer fails on the environment variable lookup

This ensures that the deployment process can properly access all required environment variables when executing the PolicyDeployer script
