### PR TITLE
Fix/readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ For this prompt, enter `newton_trading_agent.allow` and press enter. This corres
 Confirm Chain ID (e.g. mainnet = 1, sepolia = 11155111):
 ```
 
-For this prompt, input 11155111 as you should be deploying to sepolia. If this errors, check that your `RPC_URL` parameter in your `.env` file is an ethereum sepolia url (should say so in the url).
+For this prompt, input 11155111 if you are testing to deploy to sepolia. If this errors, check that your `RPC_URL` parameter in your `.env` file is an ethereum sepolia url (should say so in the url).
 
 ```
 Input policy approval expiration time in seconds (default 1 hour, good for debugging):


### PR DESCRIPTION
# Problem

- README documented incorrect prompt order for `make upload-and-deploy-policy` command
  - Chain ID and expiration time prompts were shown in wrong sequence
  - cli: <img width="717" height="80" alt="prompts" src="https://github.com/user-attachments/assets/4fa97df1-4d72-4df8-a05a-7dff15e261f7" />
  - readme: <img width="688" height="293" alt="prompts_readme" src="https://github.com/user-attachments/assets/8bc24191-08ee-4e24-95fd-58bbc18037c0" />
- `policy.wasm` overview section contained unnecessary content
  - <img width="681" height="318" alt="extra_line_readme" src="https://github.com/user-attachments/assets/bb8bea84-8ed4-49bf-8d56-6c9423f1b23f" />


# Changes

- Fixed quickstart walkthrough prompt sequence (lines 108-117) to match actual CLI implementation
  - Chain ID prompt now appears before expiration time prompt
- Cleaned up Policy Files Overview > policy.wasm section by removing extraneous line

# Testing

- Verified prompt order against Makefile implementation
- Confirmed execution flow by running `make upload-and-deploy-policy` in terminal